### PR TITLE
add consumers count field to filters and output of list-topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Lists topics.
   - filter (list topics with the specified filter in the name)
   - enqueued (remove topics for which the number of enqueued messages meets the enqueued filter)
   - dequeued (remove topics for which the number of dequeued messages meets the dequeued filter)   
+  - consumers (list topics for which the number of consumers meets the consumers filter)
 
 Example 1:`topics --filter foo`
 


### PR DESCRIPTION
Adding consumers count field to list-topics filters and output. Example:

topic_name>list-topics
  Topic Name                                                  Consumers  Enqueued  Dequeued
  ----------------------------------------------------------  ---------  --------  --------
  ActiveMQ.topic                                                    0          7         0

I run "sbt test" but even without any changes I get

Failed tests:
[error]         amazonmq.cli.command.QueueCommandsTests
[error]         amazonmq.cli.command.TopicCommandsTests

against AWS MQ 5.15.15 and 5.15.10 (help says that amazonmq.cli has "ActiveMQ 5.15.11 compatibility")

Can you please point to instruction for testing?